### PR TITLE
Local Frame option for GoThroughPositionTask

### DIFF
--- a/omniisaacgymenvs/cfg/task/ASV/GoThroughPosition.yaml
+++ b/omniisaacgymenvs/cfg/task/ASV/GoThroughPosition.yaml
@@ -13,6 +13,9 @@ defaults:
   - penalty: penalties.yaml
   - _self_
 
+sub_task:
+  reference_frame: local
+
 # if given, will override the device setting in gym. 
 env:
   numEnvs: ${resolve_default:64,${...num_envs}}

--- a/omniisaacgymenvs/cfg/task/sub_task/GoThroughPosition.yaml
+++ b/omniisaacgymenvs/cfg/task/sub_task/GoThroughPosition.yaml
@@ -2,6 +2,7 @@ name: GoThroughPosition
 position_tolerance: 0.1
 kill_after_n_steps_in_tolerance: 1 # 10seconds
 kill_dist: 8.0
+reference_frame: global
 target_linear_velocity_curriculum:
   rate_parameters:
     function: ${if:${.....test},none,sigmoid}

--- a/omniisaacgymenvs/robots/articulations/heron.py
+++ b/omniisaacgymenvs/robots/articulations/heron.py
@@ -52,7 +52,7 @@ class Heron(Robot):
 
         # get script execution path
         script_path = os.path.join(os.getcwd())
-        self._usd_path = os.path.join(script_path,"robots/usd/heron.usd") #TODO: use nucleous or relative path
+        self._usd_path = os.path.join(script_path,"robots/usd/heron.usd")
         self._name = name
 
         if self._usd_path is None:

--- a/omniisaacgymenvs/tasks/ASV_Virtual.py
+++ b/omniisaacgymenvs/tasks/ASV_Virtual.py
@@ -203,7 +203,7 @@ class ASVVirtual(RLTask):
             self.action_space = spaces.Tuple([spaces.Discrete(2)] * self._max_actions)
         elif self._discrete_actions == "Continuous":
             self.action_space = spaces.Box(
-                low=np.array([-1.0, -1.0]), high=np.array([1.0, 1.0]), dtype=np.float32
+                low=np.array([-1.0, -1.0]), high=np.array([1.0, 1.0]), dtype=np.float64
             )
         elif self._discrete_actions == "Discrete":
             raise NotImplementedError("The Discrete control mode is not supported.")

--- a/omniisaacgymenvs/tasks/common_3DoF/core.py
+++ b/omniisaacgymenvs/tasks/common_3DoF/core.py
@@ -95,21 +95,78 @@ class Core:
             dtype=torch.float32,
         )
 
-    def update_observation_tensor(self, current_state: dict) -> torch.Tensor:
+    def update_observation_tensor_local(self, current_state: dict):
         """
-        Updates the observation tensor with the current state of the robot.
+        Update the observation tensor in the local frame.
 
         Args:
-            current_state (dict): The current state of the robot.
+            current_state (dict): The current state of the system.
 
         Returns:
-            torch.Tensor: The observation tensor.
+            None
+        """
+
+        # Orientation cos, sin of USV in the global frame
+        cos_theta = current_state["orientation"][:, 0]
+        sin_theta = current_state["orientation"][:, 1]
+
+        # Transform linear velocity to the local frame
+        vel_i = (
+            cos_theta * current_state["linear_velocity"][:, 0]
+            + sin_theta * current_state["linear_velocity"][:, 1]
+        )
+        vel_j = (
+            -sin_theta * current_state["linear_velocity"][:, 0]
+            + cos_theta * current_state["linear_velocity"][:, 1]
+        )
+        transformed_velocity = torch.stack((vel_i, vel_j), dim=1)
+
+        self._obs_buffer[:, 0:2] = current_state["orientation"]
+        self._obs_buffer[:, 2:4] = transformed_velocity
+        self._obs_buffer[:, 4] = current_state["angular_velocity"]
+        self._obs_buffer[:, 5] = self._task_label
+        self._obs_buffer[:, 6:6 + self._dim_task_data] = self._task_data
+
+    def update_observation_tensor_global(self, current_state: dict):
+        """
+        Updates the observation tensor with the current state.
+
+        Args:
+            current_state (dict): A dictionary containing the current state of the environment.
+
+        Returns:
+            None
         """
         self._obs_buffer[:, 0:2] = current_state["orientation"]
         self._obs_buffer[:, 2:4] = current_state["linear_velocity"]
         self._obs_buffer[:, 4] = current_state["angular_velocity"]
         self._obs_buffer[:, 5] = self._task_label
         self._obs_buffer[:, 6:6 + self._dim_task_data] = self._task_data
+
+
+    def update_observation_tensor(self, current_state: dict, reference_frame: str = "global") -> torch.Tensor:
+        """
+        Update the observation tensor based on the current state and reference frame.
+
+        Args:
+            current_state (dict): The current state of the environment.
+            reference_frame (str, optional): The reference frame to use for updating the observation tensor.
+                Can be either "local" or "global". Defaults to "global".
+
+        Returns:
+            torch.Tensor: The updated observation tensor.
+
+        Raises:
+            ValueError: If the reference frame is neither "local" nor "global".
+        """
+
+        if reference_frame == "local":
+            self.update_observation_tensor_local(current_state)
+        elif reference_frame == "global":
+            self.update_observation_tensor_global(current_state)
+        else:
+            raise ValueError("The reference frame must be either 'local' or 'global'.")
+
         return self._obs_buffer
     
     def create_stats(self, stats: dict) -> dict:

--- a/omniisaacgymenvs/tasks/common_3DoF/task_parameters.py
+++ b/omniisaacgymenvs/tasks/common_3DoF/task_parameters.py
@@ -116,6 +116,7 @@ class GoThroughPositionParameters:
     kill_after_n_steps_in_tolerance: int = 1
     goal_random_position: float = 0.0
     kill_dist: float = 10.0
+    reference_frame: str = "world"
 
     target_linear_velocity_curriculum: CurriculumParameters = field(
         default_factory=dict


### PR DESCRIPTION
This PR includes the possibility of using observations in the local frame for the GoThroughPosition task. 


Considerations
- Transformations implemented in the GoThroughPositionTask class handle task-specific observations and are based on the reference_frame configuration. (global or local)
- Transformations implemented in the Core handle observations that can be common for multiple tasks. Enforcing this update in the Core level can be useful for multitask agents in future work. 
- The implementation in the core defaults to global reference frame to keep compatibility with other tasks that might not have implemented the option of local frame observations.

Tested for the ASV with the following command:
`/isaac-sim/python.sh scripts/rlgames_train_RANS.py task=ASV/GoThroughPosition train=ASV/ASV_PPOcontinuous_MLP.yaml num_envs=2048`
